### PR TITLE
feature(gpgkey): support signing by gpg key

### DIFF
--- a/MacOS/bash_profile.sh
+++ b/MacOS/bash_profile.sh
@@ -121,6 +121,10 @@ alias gpgGenOld='gpg --default-new-key-algo rsa4096 --gen-key'
 alias gpgAddToGlobal='git config --global user.signingkey $1 && git config --global commit.gpgsign true'
 alias gpgAddToLocal='git config --local user.signingkey $1 && git config --local commit.gpgsign true'
 alias gpgPublicKey='gpg --armor --export GPG key $1'
+alias gpgSignCommit='GIT_TRACE=1 git commit -S -m $1'
+alias gpgGrantPermissionUser='sudo chown -R $1 ~$1/.gnupg'
+alias gpgCheckSign='sudo echo "Is commit message signed?" | gpg --clearsign'
+align gpgIsEnable='git config -l | grep gpg'
 
 function gpgEdit() {
   gpg --edit-key GPG key $1
@@ -132,6 +136,14 @@ function gpgUpdatePath() {
   echo 'export GPG_TTY=$(tty)' >> ~/.profile
 }
 
+function gpgTroubleShoot() {
+  echo '$ gpgSignCommit [message]: sign commit with trace the error'
+  echo '$ gpgGrantPermissionUser [user]: allow user can run the gpg command'
+  echo '$ gpgCheckSign: check wether sign or not'
+  echo '$ export GPG_TTY=$(tty): if we saw the error Inappropriate ioctl for device'
+  echo '$ gpgIsEnable: check to know whether enable sign or not'
+}
+
 function gpgCLIs() {
   echo '$ gpgGen:  generate new GPG keys (gpg version > 2.1.17) else $ gpgGenOld'
   echo '$ gpgKeys: list GPG keys for which you have both a public and private key'
@@ -140,6 +152,7 @@ function gpgCLIs() {
   echo '$ gpgUpdatePath: update environment on shell to use GPG key'
   echo '$ gpgAddToGlobal KEY_ID: add KEY_ID to sign on config global of git'
   echo '$ gpgAddToLocal KEY_ID: add KEY_ID to sign on config local of git'
+  echo '$ gpgTroubleShoot: show related issue on gpg when signing often is permission'
 }
 
 #==============================================#

--- a/MacOS/bash_profile.sh
+++ b/MacOS/bash_profile.sh
@@ -104,8 +104,10 @@ function androidTools() {
 }
 
 androidCLIs() {
+  echo '==========================================='
   echo 'show list android emulators: $ emulators'
   echo 'launch a specific emulator :  $startEmulator $emulator_name'
+  echo '==========================================='
 }
 alias emulators="emulator -list-avds"
 startEmulator() {
@@ -124,35 +126,43 @@ alias gpgPublicKey='gpg --armor --export GPG key $1'
 alias gpgSignCommit='GIT_TRACE=1 git commit -S -m $1'
 alias gpgGrantPermissionUser='sudo chown -R $1 ~$1/.gnupg'
 alias gpgCheckSign='sudo echo "Is commit message signed?" | gpg --clearsign'
-align gpgIsEnable='git config -l | grep gpg'
+alias gpgIsEnable='git config -l | grep gpg'
 
 function gpgEdit() {
+  echo '==========================================='
   gpg --edit-key GPG key $1
   echo '$ gpg> adduid: to add the user ID details'
+  echo '==========================================='
 }
 
 function gpgUpdatePath() {
+  echo '==========================================='
   test -r ~/.bash_profile && echo 'export GPG_TTY=$(tty)' >> ~/.bash_profile
   echo 'export GPG_TTY=$(tty)' >> ~/.profile
+  echo '==========================================='
 }
 
 function gpgTroubleShoot() {
+  echo '==========================================='
   echo '$ gpgSignCommit [message]: sign commit with trace the error'
   echo '$ gpgGrantPermissionUser [user]: allow user can run the gpg command'
   echo '$ gpgCheckSign: check wether sign or not'
   echo '$ export GPG_TTY=$(tty): if we saw the error Inappropriate ioctl for device'
   echo '$ gpgIsEnable: check to know whether enable sign or not'
+  echo '==========================================='
 }
 
 function gpgCLIs() {
+  echo '==========================================='
   echo '$ gpgGen:  generate new GPG keys (gpg version > 2.1.17) else $ gpgGenOld'
   echo '$ gpgKeys: list GPG keys for which you have both a public and private key'
   echo '$ gpgEdit: associating an email with your GPG key'
-  echo '$ gpgPublicKey KEY_ID: get public key to add to github or receiver to verify signing'
+  echo '$ gpgPublicKey [KEY_ID]: get public key to add to github or receiver to verify signing'
   echo '$ gpgUpdatePath: update environment on shell to use GPG key'
-  echo '$ gpgAddToGlobal KEY_ID: add KEY_ID to sign on config global of git'
-  echo '$ gpgAddToLocal KEY_ID: add KEY_ID to sign on config local of git'
+  echo '$ gpgAddToGlobal [KEY_ID]: add KEY_ID to sign on config global of git'
+  echo '$ gpgAddToLocal [KEY_ID]: add KEY_ID to sign on config local of git'
   echo '$ gpgTroubleShoot: show related issue on gpg when signing often is permission'
+  echo '==========================================='
 }
 
 #==============================================#

--- a/MacOS/bash_profile.sh
+++ b/MacOS/bash_profile.sh
@@ -112,6 +112,35 @@ startEmulator() {
   emulator -avd $1
 }
 
+#==============================================#
+# gpg keys to sign commit, tag...
+#==============================================#
+alias gpgKeys='gpg --list-secret-keys --keyid-format LONG'
+alias gpgGen='gpg --full-generate-key'
+alias gpgGenOld='gpg --default-new-key-algo rsa4096 --gen-key'
+alias gpgAddToGlobal='git config --global user.signingkey $1 && git config --global commit.gpgsign true'
+alias gpgAddToLocal='git config --local user.signingkey $1 && git config --local commit.gpgsign true'
+alias gpgPublicKey='gpg --armor --export GPG key $1'
+
+function gpgEdit() {
+  gpg --edit-key GPG key $1
+  echo '$ gpg> adduid: to add the user ID details'
+}
+
+function gpgUpdatePath() {
+  test -r ~/.bash_profile && echo 'export GPG_TTY=$(tty)' >> ~/.bash_profile
+  echo 'export GPG_TTY=$(tty)' >> ~/.profile
+}
+
+function gpgCLIs() {
+  echo '$ gpgGen:  generate new GPG keys (gpg version > 2.1.17) else $ gpgGenOld'
+  echo '$ gpgKeys: list GPG keys for which you have both a public and private key'
+  echo '$ gpgEdit: associating an email with your GPG key'
+  echo '$ gpgPublicKey KEY_ID: get public key to add to github or receiver to verify signing'
+  echo '$ gpgUpdatePath: update environment on shell to use GPG key'
+  echo '$ gpgAddToGlobal KEY_ID: add KEY_ID to sign on config global of git'
+  echo '$ gpgAddToLocal KEY_ID: add KEY_ID to sign on config local of git'
+}
 
 #==============================================#
 # Trigger other scripts run to activate tools


### PR DESCRIPTION
**The context**
You can sign commits and tags locally, so other people can verify that your work comes from a trusted source

**The solution**
Using GPG or S/MIME. Both S/MIME and PGP use Public Key Cryptography, yet both are two different standards. The main difference is S/MIME depends on a centralized trusted authority for verification of public keys, but PGP does not need that.
**This PR**: add utility commands to support using GPG
